### PR TITLE
Hide nav when not scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -93,3 +93,8 @@ footer p {
         flex-wrap: wrap;
     }
 }
+
+
+.hide {
+    display: none;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -32,17 +32,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
     buildNav();
 
-
-    // Objective: Hide nav when not scrolling. 
-    // Current state: This only fires once on the first scroll event after 3 seconds and does not adjust (restart timer) for proceeding events.
-    document.addEventListener('scroll', function (e){
-        setTimeout(function hideNav(){
-            const nav = document.getElementById('nav');
-            nav.style.display = 'none';
-        }, 3000);
-    });
-
-
     const options = {
     root: null,   // This is the viewport
     threshold: 1,   // 0 value will fire for any part of the target. 1 value will fire if 100% of the target is visible inside the viewport  

--- a/js/app.js
+++ b/js/app.js
@@ -32,6 +32,17 @@ window.addEventListener('DOMContentLoaded', () => {
 
     buildNav();
 
+
+    // Objective: Hide nav when not scrolling. 
+    // Current state: This only fires once on the first scroll event after 3 seconds and does not adjust (restart timer) for proceeding events.
+    document.addEventListener('scroll', function (e){
+        setTimeout(function hideNav(){
+            const nav = document.getElementById('nav');
+            nav.style.display = 'none';
+        }, 3000);
+    });
+
+
     const options = {
     root: null,   // This is the viewport
     threshold: 1,   // 0 value will fire for any part of the target. 1 value will fire if 100% of the target is visible inside the viewport  

--- a/js/app.js
+++ b/js/app.js
@@ -32,6 +32,17 @@ window.addEventListener('DOMContentLoaded', () => {
 
     buildNav();
 
+    
+    // Objective: Hide nav when not scrolling. 
+    // Current state: setTimeout is not waiting for user to stop scrolling. It's triggering a 3 second delay for the first scroll event.
+    document.addEventListener('scroll', function (e){
+        setTimeout(function hideNav(){
+            const nav = document.getElementById('nav');
+            nav.style.display = 'none';
+        }, 3000);
+    });
+    
+
     const options = {
     root: null,   // This is the viewport
     threshold: 1,   // 0 value will fire for any part of the target. 1 value will fire if 100% of the target is visible inside the viewport  

--- a/js/app.js
+++ b/js/app.js
@@ -32,20 +32,26 @@ window.addEventListener('DOMContentLoaded', () => {
 
     buildNav();
 
-    
     // Hide navigation bar when scrolling
     let timer = null;
     let nav = document.getElementById('nav');
     window.addEventListener('scroll', function() {
 
-    // TODO: Ensure navigation is permanently visible when scrolled to top of page
+    // TODO: Look for a more performant solution.    
+    console.log(this.window.scrollY);
+
         if(timer !== null) {
             clearTimeout(timer);  
             nav.style.display = 'block';      
         }
         
         timer = setTimeout(function() {
-              nav.style.display = 'none';
+              // Ensure navigation is permanently visible when scrolled to top of page
+              if (this.window.scrollY === 0){
+                  nav.style.display = 'block';
+              } else {
+                nav.style.display = 'none';
+              }
         }, 1000);
     }, false);
 

--- a/js/app.js
+++ b/js/app.js
@@ -33,16 +33,24 @@ window.addEventListener('DOMContentLoaded', () => {
     buildNav();
 
     
-    // Objective: Hide nav when not scrolling. 
-    // Current state: setTimeout is not waiting for user to stop scrolling. It's triggering a 3 second delay for the first scroll event.
-    document.addEventListener('scroll', function (e){
-        setTimeout(function hideNav(){
-            const nav = document.getElementById('nav');
-            nav.style.display = 'none';
-        }, 3000);
-    });
-    
+    // Hide navigation bar when scrolling
+    let timer = null;
+    let nav = document.getElementById('nav');
+    window.addEventListener('scroll', function() {
 
+    // TODO: Ensure navigation is permanently visible when scrolled to top of page
+        if(timer !== null) {
+            clearTimeout(timer);  
+            nav.style.display = 'block';      
+        }
+        
+        timer = setTimeout(function() {
+              nav.style.display = 'none';
+        }, 1000);
+    }, false);
+
+
+    // Intersection Observer - Is a given section visible in the viewport? If so, make it stand out with an active class.
     const options = {
     root: null,   // This is the viewport
     threshold: 1,   // 0 value will fire for any part of the target. 1 value will fire if 100% of the target is visible inside the viewport  


### PR DESCRIPTION
This change adds a fixed navigation bar which is made visible/invisible based on scrolling and timing. If the user is at the top of the page, window.scrollY position of 0, this is permanently visible. Otherwise, while the user is not scrolling, the nav bar will be hidden from view after about 1 second.